### PR TITLE
Folder not found bug fix

### DIFF
--- a/slack_history.py
+++ b/slack_history.py
@@ -89,6 +89,11 @@ def channelRename( oldRoomName, newRoomName ):
 
 
 def writeMessageFile( fileName, messages ):
+	directory = os.path.dirname(fileName)
+
+	if not os.path.isdir( directory ):
+		mkdir( directory )
+
 	with open(fileName, 'w') as outFile:
 		json.dump( messages, outFile, indent=4)
 


### PR DESCRIPTION
When saving the channel history in some cases the folder of the channel does not exist and the following script crashes. Added quick fix.